### PR TITLE
Preparation of crate.io release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ jobs:
 
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Check formatting
           command: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs"]
+	path = libs
+	url = https://github.com/georgbramm/bn

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "rabe"
 version = "0.1.2"
 authors = ["Schanzenbach, Martin <martin.schanzenbach@aisec.fraunhofer.de>", "Bramm, Georg <georg.bramm@aisec.fraunhofer.de>", "Schuette, Julian <julian.schuette@aisec.fraunhofer.de>"]
 license = "MIT"
+description = "Rabe is a library for Attribute Based Encryption (ABE), supporting several Ciphertext-Policy (CP-ABE) and Key Policy (KP-ABE) schemes."
+repository = "https://github.com/Fraunhofer-AISEC/rabe"
 
 [lib]
 name="rabe"
@@ -11,7 +13,7 @@ crate-type=["rlib", "cdylib"]
 [dependencies]
 arrayref = "0.3.4"
 libc = "0.2.0"
-bn = { git = "https://github.com/georgbramm/bn" }
+bn = { path = "libs/bn-update", version="0.4.4" }
 blake2-rfc = "0.2.17"
 rand = "0.3"
 rust-crypto = "0.2.36"
@@ -24,3 +26,9 @@ serde_cbor = "0.9"
 serde_derive = "1.0.16"
 clap = "2.27.1"
 base64 = "0.10.1"
+
+[patch.crates-io]
+bn = { path = "libs/bn-update" }
+
+[badges]
+circle-ci = { repository = "Fraunhofer-AISEC/rabe", branch = "master" }


### PR DESCRIPTION
This project depends on `georgbramm/bn` which is a fork of `zcash-hackworks/bn`. The former is not available as a crate, the latter seems to be not maintained anymore (the last PR is open for >2yrs).

Publishing to crates.io requires all dependencies to be available on crate.io as well. So, there are only two options:

1) Create a PR and convince the maintainers of `zcash-hackworks` to accept and publish it as a version bn:0.4.4

2) Publish `georgbramm/bn` as a whole new crate, say under the name `bn-serde`.

3) Include `georgbramm/bn` as a submodule into this project and bundle it into the published crate


This PR does (3).

(1) would obviously be favorable, but the chances of convincing the zcash authors to accept a major breaking PR in the near future are low.

(2) is irreversible and may lead to further confusion

(3) is not elegant, but it can easily be reverted in case an updated version of `bn` is published in the future